### PR TITLE
feat(printer): improve NullRawPrinter error message with config hint

### DIFF
--- a/Kasir.Core/Hardware/NullRawPrinter.cs
+++ b/Kasir.Core/Hardware/NullRawPrinter.cs
@@ -2,7 +2,7 @@ namespace Kasir.Hardware
 {
     public class NullRawPrinter : IRawPrinter
     {
-        public string LastError => "printer_name belum diset (NullRawPrinter aktif)";
+        public string LastError => "printer_name belum diset — pilih printer di menu Admin → Printer Config";
         public bool Send(byte[] data) => false;
     }
 }


### PR DESCRIPTION
## Summary
- Improve `NullRawPrinter.LastError` message to guide users to Admin → Printer Config when no printer is configured

## Test plan
- [ ] CI passes