### PR TITLE
feat(chrome): footer status badges — printer + cloud + version

### DIFF
--- a/.omc/plans/open-questions.md
+++ b/.omc/plans/open-questions.md
@@ -28,3 +28,20 @@
   Apply NumericInputBehavior to TxtCash/TxtCard/TxtVoucher.
 
 - [x] **Migration version numbering** — Existing migrations: `Migration_002.cs`, `Migration_003.cs`, `Migration_004.cs`. **Migration_005 IS the sequential next** — there is no gap. Planner's note about "skipped 003/004" was incorrect. Use `Migration_005` as planned.
+
+---
+
+## footer-chrome — 2026-05-07 (OPEN)
+
+- [ ] **HTTPS update channel** — `UpdateService` currently checks LAN-only `update_share` UNC path (default `\\KASIR01\kasir\updates\latest`). On Mac dev or any register without LAN access to the Hub, "Periksa Update" returns "Tidak dapat terhubung ke server update". Single point of failure: if Hub register is offline, no register can auto-update.
+
+  **Proposed fix**: Add HTTPS fallback channel polling GitHub Releases:
+  - New config row `update_url` defaulting to `https://api.github.com/repos/Panandika/kasir-pos/releases/latest`
+  - Modify `UpdateService.CheckForUpdate()` to try LAN UNC first, fall back to HTTPS if UNC fails OR if `update_url` is set and `update_share` is empty
+  - `UpdateStatusModel` (footer badge) honors HTTPS path automatically once UpdateService supports it
+  - Apply-update flow still downloads the .exe; HTTPS download via `HttpClient` with progress reporting
+  - Rate limit: GitHub anonymous API allows 60 req/hour per IP — fine for daily check
+  
+  **Scope**: ~3-4 files (`UpdateService.cs`, config seed in `DbConnection.cs`, `UpdateView.axaml.cs` to show channel source). New tests for HTTPS path. Optionally: code signature verification before applying downloaded .exe (defer).
+
+  **Why deferred**: out of scope for current footer-chrome PR (#29). Logged as separate follow-up. Current PR's `UpdateStatusModel` correctly reflects whatever UpdateService returns — adding HTTPS later requires zero changes to the footer model.

--- a/Kasir.Avalonia/App.axaml.cs
+++ b/Kasir.Avalonia/App.axaml.cs
@@ -2,6 +2,9 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Kasir.Avalonia.Infrastructure;
+using Kasir.Data;
+using Kasir.Data.Repositories;
+using Kasir.Hardware;
 
 namespace Kasir.Avalonia;
 
@@ -22,6 +25,24 @@ public partial class App : Application
             desktop.MainWindow = new ShellWindow();
         }
 
+        // Footer status models — best-effort, must not block UI thread.
+        PrinterStatusModel.Current.Start(BuildPrinter);
+        UpdateStatusModel.Current.Start();
+        CloudSyncStatusModel.Current.Start();
+
         base.OnFrameworkInitializationCompleted();
+    }
+
+    private static IReceiptPrinter? BuildPrinter()
+    {
+        try
+        {
+            var conn = DbConnection.GetConnection();
+            return new ReceiptPrinter(new ConfigRepository(conn));
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/Kasir.Avalonia/App.axaml.cs
+++ b/Kasir.Avalonia/App.axaml.cs
@@ -37,7 +37,8 @@ public partial class App : Application
     {
         try
         {
-            var conn = DbConnection.GetConnection();
+            // Background timer thread — must not call GetConnection() (UI-thread-only).
+            var conn = DbConnection.CreateConnection();
             return new ReceiptPrinter(new ConfigRepository(conn));
         }
         catch

--- a/Kasir.Avalonia/Forms/Admin/CloudSyncSetupView.axaml
+++ b/Kasir.Avalonia/Forms/Admin/CloudSyncSetupView.axaml
@@ -1,0 +1,196 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Kasir.Avalonia.Forms.Admin.CloudSyncSetupView"
+             Background="{DynamicResource Bg0Brush}">
+  <DockPanel>
+    <Panel DockPanel.Dock="Bottom" Background="{DynamicResource Bg2Brush}" Height="28">
+      <TextBlock x:Name="StatusLabel"
+                 Foreground="{DynamicResource FgPrimaryBrush}"
+                 FontFamily="{DynamicResource JetBrainsMonoFont}"
+                 FontSize="12"
+                 VerticalAlignment="Center"
+                 Margin="8,0" />
+    </Panel>
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+      <StackPanel HorizontalAlignment="Center"
+                  VerticalAlignment="Top"
+                  Spacing="12"
+                  Width="620"
+                  Margin="0,16,0,16">
+
+        <TextBlock Text="CLOUD SYNC"
+                   FontSize="20"
+                   FontWeight="Bold"
+                   Foreground="{DynamicResource FgPrimaryBrush}"
+                   HorizontalAlignment="Center"
+                   FontFamily="{DynamicResource JetBrainsMonoFont}" />
+
+        <!-- STATUS panel -->
+        <Border Background="{DynamicResource Bg1Brush}"
+                BorderBrush="{DynamicResource BorderStrongBrush}"
+                BorderThickness="1"
+                Padding="12">
+          <StackPanel Spacing="6">
+            <TextBlock Text="STATUS"
+                       FontWeight="Bold"
+                       Foreground="{DynamicResource FgSecondaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}"
+                       FontSize="12" />
+            <Grid ColumnDefinitions="160,*" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="2">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="State:"
+                         Foreground="{DynamicResource FgSecondaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBlock Grid.Row="0" Grid.Column="1" x:Name="LblState"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="Antrian:"
+                         Foreground="{DynamicResource FgSecondaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBlock Grid.Row="1" Grid.Column="1" x:Name="LblQueue"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="Heartbeat:"
+                         Foreground="{DynamicResource FgSecondaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBlock Grid.Row="2" Grid.Column="1" x:Name="LblHeartbeat"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBlock Grid.Row="3" Grid.Column="0" Text="Pesan:"
+                         Foreground="{DynamicResource FgSecondaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBlock Grid.Row="3" Grid.Column="1" x:Name="LblTestResult"
+                         TextWrapping="Wrap"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+            </Grid>
+          </StackPanel>
+        </Border>
+
+        <!-- KONEKSI form -->
+        <Border Background="{DynamicResource Bg1Brush}"
+                BorderBrush="{DynamicResource BorderStrongBrush}"
+                BorderThickness="1"
+                Padding="12">
+          <StackPanel Spacing="8">
+            <TextBlock Text="KONEKSI"
+                       FontWeight="Bold"
+                       Foreground="{DynamicResource FgSecondaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}"
+                       FontSize="12" />
+
+            <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="6">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="Host:"
+                         VerticalAlignment="Center"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBox Grid.Row="0" Grid.Column="1" x:Name="TxtHost"
+                       PlaceholderText="aws-1-ap-southeast-1.pooler.supabase.com"
+                       Background="{DynamicResource Bg0Brush}"
+                       Foreground="{DynamicResource FgPrimaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="Port:"
+                         VerticalAlignment="Center"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBox Grid.Row="1" Grid.Column="1" x:Name="TxtPort"
+                       Text="6543"
+                       Background="{DynamicResource Bg0Brush}"
+                       Foreground="{DynamicResource FgPrimaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="Database:"
+                         VerticalAlignment="Center"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBox Grid.Row="2" Grid.Column="1" x:Name="TxtDatabase"
+                       Text="postgres"
+                       Background="{DynamicResource Bg0Brush}"
+                       Foreground="{DynamicResource FgPrimaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+
+              <TextBlock Grid.Row="3" Grid.Column="0" Text="Username:"
+                         VerticalAlignment="Center"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBox Grid.Row="3" Grid.Column="1" x:Name="TxtUsername"
+                       PlaceholderText="postgres.xxxxxxxxxxxx"
+                       Background="{DynamicResource Bg0Brush}"
+                       Foreground="{DynamicResource FgPrimaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+
+              <TextBlock Grid.Row="4" Grid.Column="0" Text="Password:"
+                         VerticalAlignment="Center"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBox Grid.Row="4" Grid.Column="1" x:Name="TxtPassword"
+                       PasswordChar="•"
+                       Background="{DynamicResource Bg0Brush}"
+                       Foreground="{DynamicResource FgPrimaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+
+              <TextBlock Grid.Row="5" Grid.Column="0" Text="SSL Mode:"
+                         VerticalAlignment="Center"
+                         Foreground="{DynamicResource FgPrimaryBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+              <TextBlock Grid.Row="5" Grid.Column="1" Text="Require (kunci)"
+                         VerticalAlignment="Center"
+                         Foreground="{DynamicResource FgDimBrush}"
+                         FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+            </Grid>
+          </StackPanel>
+        </Border>
+
+        <!-- Buttons -->
+        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+          <Button x:Name="BtnTest"
+                  Content="F5 Uji Koneksi"
+                  Width="170" Height="34"
+                  Background="{DynamicResource BgSelectedBrush}"
+                  Foreground="{DynamicResource FgPrimaryBrush}"
+                  FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+          <Button x:Name="BtnSave"
+                  Content="F10 Simpan"
+                  Width="170" Height="34"
+                  Background="{DynamicResource BgSelectedBrush}"
+                  Foreground="{DynamicResource FgPrimaryBrush}"
+                  FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+          <Button x:Name="BtnBack"
+                  Content="Esc Kembali"
+                  Width="170" Height="34"
+                  Background="{DynamicResource Bg1Brush}"
+                  Foreground="{DynamicResource FgSecondaryBrush}"
+                  FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="13" />
+        </StackPanel>
+
+        <!-- Note -->
+        <Border Background="{DynamicResource Bg1Brush}"
+                BorderBrush="{DynamicResource BorderStrongBrush}"
+                BorderThickness="1"
+                Padding="12">
+          <StackPanel Spacing="4">
+            <TextBlock Text="CATATAN DEV"
+                       FontWeight="Bold"
+                       Foreground="{DynamicResource FgSecondaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="11" />
+            <TextBlock Text="Buka dua terminal untuk dev:"
+                       Foreground="{DynamicResource FgSecondaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="12"
+                       TextWrapping="Wrap" />
+            <TextBlock Text="  Terminal 1: dotnet run --project Kasir.Avalonia"
+                       Foreground="{DynamicResource FgPrimaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="12" />
+            <TextBlock Text="  Terminal 2: dotnet run --project Kasir.CloudSync"
+                       Foreground="{DynamicResource FgPrimaryBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="12" />
+            <TextBlock Text="Produksi (Win10 gateway): lihat docs/NEXT-STEPS.md"
+                       Foreground="{DynamicResource FgDimBrush}"
+                       FontFamily="{DynamicResource JetBrainsMonoFont}" FontSize="12"
+                       TextWrapping="Wrap" />
+          </StackPanel>
+        </Border>
+
+      </StackPanel>
+    </ScrollViewer>
+  </DockPanel>
+</UserControl>

--- a/Kasir.Avalonia/Forms/Admin/CloudSyncSetupView.axaml.cs
+++ b/Kasir.Avalonia/Forms/Admin/CloudSyncSetupView.axaml.cs
@@ -1,0 +1,176 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Kasir.Avalonia.Forms.Shared;
+using Kasir.Avalonia.Infrastructure;
+using Kasir.Avalonia.Navigation;
+using Kasir.Avalonia.Utils;
+using Npgsql;
+
+namespace Kasir.Avalonia.Forms.Admin;
+
+public partial class CloudSyncSetupView : UserControl
+{
+    private readonly CloudSyncStatusModel _status = CloudSyncStatusModel.Current;
+
+    public CloudSyncSetupView()
+    {
+        InitializeComponent();
+
+        LoadCredsIntoForm();
+        RefreshStatusPanel();
+
+        _status.PropertyChanged += OnStatusChanged;
+
+        BtnTest.Click += async (_, _) => await OnTest();
+        BtnSave.Click += async (_, _) => await OnSave();
+        BtnBack.Click += (_, _) => NavigationService.GoBack();
+
+        FooterStatus.RegisterDefault(StatusLabel, "Cloud Sync — F5=Uji Koneksi  F10=Simpan  Esc=Keluar");
+    }
+
+    protected override void OnDetachedFromVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+    {
+        _status.PropertyChanged -= OnStatusChanged;
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (e.Handled) return;
+        if (KeyboardRouter.IsEscape(e)) { e.Handled = true; NavigationService.GoBack(); return; }
+        if (e.Key == Key.F5) { e.Handled = true; _ = OnTest(); return; }
+        if (e.Key == Key.F10) { e.Handled = true; _ = OnSave(); return; }
+    }
+
+    private void LoadCredsIntoForm()
+    {
+        var c = CloudSyncCredsService.Load();
+        if (c is null) return;
+        TxtHost.Text = c.Host;
+        TxtPort.Text = c.Port.ToString();
+        TxtDatabase.Text = c.Database;
+        TxtUsername.Text = c.Username;
+        TxtPassword.Text = c.Password;
+    }
+
+    private void OnStatusChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(RefreshStatusPanel);
+    }
+
+    private void RefreshStatusPanel()
+    {
+        LblState.Text = _status.DisplayText;
+        LblQueue.Text = _status.QueueDepth > 0 ? $"{_status.QueueDepth} antri" : "0";
+        LblHeartbeat.Text = _status.State switch
+        {
+            CloudSyncState.Connected    => "OK",
+            CloudSyncState.Queued       => "OK (ada antrian)",
+            CloudSyncState.Waking       => "membangunkan…",
+            CloudSyncState.Disconnected => "offline",
+            CloudSyncState.Error        => "gagal",
+            _                           => "-"
+        };
+    }
+
+    private bool TryBuildCredsFromForm(out CloudSyncCreds creds, out string? error)
+    {
+        creds = new CloudSyncCreds();
+        var host = (TxtHost.Text ?? "").Trim();
+        var portText = (TxtPort.Text ?? "").Trim();
+        var db = (TxtDatabase.Text ?? "").Trim();
+        var user = (TxtUsername.Text ?? "").Trim();
+        var pwd = TxtPassword.Text ?? "";
+
+        if (string.IsNullOrEmpty(host)) { error = "Host wajib diisi."; return false; }
+        if (!int.TryParse(portText, out int port) || port < 1 || port > 65535)
+        { error = "Port harus angka 1-65535."; return false; }
+        if (string.IsNullOrEmpty(db)) { error = "Database wajib diisi."; return false; }
+        if (string.IsNullOrEmpty(user)) { error = "Username wajib diisi."; return false; }
+        if (string.IsNullOrEmpty(pwd)) { error = "Password wajib diisi."; return false; }
+
+        creds = new CloudSyncCreds
+        {
+            Host = host,
+            Port = port,
+            Database = db,
+            Username = user,
+            Password = pwd,
+        };
+        error = null;
+        return true;
+    }
+
+    private async Task OnTest()
+    {
+        if (!TryBuildCredsFromForm(out var creds, out var error))
+        {
+            LblTestResult.Text = error ?? "Form tidak valid.";
+            return;
+        }
+
+        LblTestResult.Text = "Menguji koneksi…";
+        BtnTest.IsEnabled = false;
+        try
+        {
+            var (ok, msg) = await ProbeAsync(creds, TimeSpan.FromSeconds(30));
+            LblTestResult.Text = ok ? "Koneksi berhasil" : $"Koneksi gagal: {msg}";
+        }
+        finally
+        {
+            BtnTest.IsEnabled = true;
+        }
+    }
+
+    private static async Task<(bool ok, string? error)> ProbeAsync(CloudSyncCreds creds, TimeSpan timeout)
+    {
+        try
+        {
+            var b = new NpgsqlConnectionStringBuilder
+            {
+                Host = creds.Host,
+                Port = creds.Port,
+                Database = creds.Database,
+                Username = creds.Username,
+                Password = creds.Password,
+                SslMode = SslMode.Require,
+                Timeout = (int)Math.Max(1, timeout.TotalSeconds),
+            };
+            using var cts = new CancellationTokenSource(timeout);
+            await using var conn = new NpgsqlConnection(b.ConnectionString);
+            await conn.OpenAsync(cts.Token).ConfigureAwait(false);
+            await using var cmd = new NpgsqlCommand("SELECT 1", conn);
+            cmd.CommandTimeout = (int)Math.Max(1, timeout.TotalSeconds);
+            await cmd.ExecuteScalarAsync(cts.Token).ConfigureAwait(false);
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
+    private async Task OnSave()
+    {
+        if (!TryBuildCredsFromForm(out var creds, out var error))
+        {
+            await MsgBox.Show(NavigationService.Owner, error ?? "Form tidak valid.");
+            return;
+        }
+
+        if (!CloudSyncCredsService.Save(creds))
+        {
+            await MsgBox.Show(NavigationService.Owner, "Gagal menyimpan konfigurasi.");
+            return;
+        }
+
+        _status.RefreshCreds();
+        await MsgBox.Show(NavigationService.Owner, "Konfigurasi tersimpan.");
+    }
+}

--- a/Kasir.Avalonia/Forms/MainMenuView.axaml.cs
+++ b/Kasir.Avalonia/Forms/MainMenuView.axaml.cs
@@ -143,6 +143,7 @@ public partial class MainMenuView : UserControl, INavigationAware
         {
             new TileSpec { Label = "User Management",  UnderlineIndex = 5, Hotkey = Key.M, Activate = () => NavigationService.Navigate(new UserView()) },
             new TileSpec { Label = "Printer Config",   UnderlineIndex = 0, Hotkey = Key.P, Activate = () => NavigationService.Navigate(new PrinterConfigView()) },
+            new TileSpec { Label = "Cloud Sync",       UnderlineIndex = 0, Hotkey = Key.C, Activate = () => NavigationService.Navigate(new CloudSyncSetupView()) },
             new TileSpec { Label = "Backup",           UnderlineIndex = 0, Hotkey = Key.B, Activate = () => NavigationService.Navigate(new BackupView()) },
             new TileSpec { Label = "Shift Management", UnderlineIndex = 0, Hotkey = Key.S, Activate = () => NavigationService.Navigate(new ShiftView(_userId)) },
             new TileSpec { Label = "Periksa Update" + (_updateBadgeVersion != null ? $"  ● v{_updateBadgeVersion}" : ""), UnderlineIndex = 8, Hotkey = Key.U, Activate = () => NavigationService.Navigate(new UpdateView()) },

--- a/Kasir.Avalonia/Infrastructure/CloudSyncCredsService.cs
+++ b/Kasir.Avalonia/Infrastructure/CloudSyncCredsService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Kasir.Avalonia.Infrastructure;
+
+public sealed class CloudSyncCreds
+{
+    public string Host { get; set; } = "";
+    public int Port { get; set; } = 6543;
+    public string Database { get; set; } = "postgres";
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}
+
+public static class CloudSyncCredsService
+{
+    private static readonly string ConfigDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Kasir");
+    public static readonly string ConfigPath = Path.Combine(ConfigDir, "cloudsync.json");
+
+    public static CloudSyncCreds? Load()
+    {
+        try
+        {
+            if (!File.Exists(ConfigPath)) return null;
+            return JsonSerializer.Deserialize<CloudSyncCreds>(File.ReadAllText(ConfigPath));
+        }
+        catch { return null; }
+    }
+
+    public static bool Save(CloudSyncCreds creds)
+    {
+        try
+        {
+            Directory.CreateDirectory(ConfigDir);
+            File.WriteAllText(ConfigPath, JsonSerializer.Serialize(creds, new JsonSerializerOptions { WriteIndented = true }));
+            return true;
+        }
+        catch { return false; }
+    }
+
+    public static void Delete()
+    {
+        try { if (File.Exists(ConfigPath)) File.Delete(ConfigPath); } catch { }
+    }
+
+    public static string BuildConnectionString(CloudSyncCreds creds)
+        => $"Host={creds.Host};Port={creds.Port};Database={creds.Database};Username={creds.Username};Password={creds.Password};SslMode=Require";
+}

--- a/Kasir.Avalonia/Infrastructure/CloudSyncStatusModel.cs
+++ b/Kasir.Avalonia/Infrastructure/CloudSyncStatusModel.cs
@@ -1,8 +1,6 @@
 using System;
 using System.ComponentModel;
-using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
@@ -32,17 +30,12 @@ public sealed class CloudSyncStatusModel : INotifyPropertyChanged
     private static readonly TimeSpan ConnectivityInterval = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan WakeTimeout = TimeSpan.FromSeconds(90);
 
-    private static readonly string ConfigDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "Kasir");
-    private static readonly string CredsPath = Path.Combine(ConfigDir, "cloudsync.json");
-
     private CloudSyncState _state = CloudSyncState.Disabled;
     private int _queueDepth;
     private int _consecutiveFailures;
     private DateTime _lastConnectivityCheck = DateTime.MinValue;
     private DateTime _lastKeepAliveDate = DateTime.MinValue.Date;
-    private CloudCreds? _creds;
+    private CloudSyncCreds? _creds;
 
     private Timer? _queueTimer;
     private Timer? _connectivityTimer;
@@ -121,6 +114,34 @@ public sealed class CloudSyncStatusModel : INotifyPropertyChanged
         // Keep-alive: tick every 30 minutes, fire at 03:00 once per day.
         _keepAliveTimer = new Timer(_ => _ = MaybeKeepAliveAsync(), null,
             TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(30));
+    }
+
+    /// <summary>
+    /// Reload credentials from disk after the user saves them in the setup
+    /// screen. If creds become available, transition to Waking and fire a
+    /// SELECT 1 probe; if creds were removed, transition to Disabled.
+    /// </summary>
+    public void RefreshCreds()
+    {
+        _creds = TryReadCreds();
+        if (_creds is null)
+        {
+            State = CloudSyncState.Disabled;
+            return;
+        }
+
+        State = CloudSyncState.Waking;
+        _consecutiveFailures = 0;
+        _ = WakeAsync();
+
+        // Ensure timers are running (in case Start() was called when creds were absent).
+        if (_queueTimer is null)
+            _queueTimer = new Timer(_ => PollQueueDepth(), null, QueuePollInterval, QueuePollInterval);
+        if (_connectivityTimer is null)
+            _connectivityTimer = new Timer(_ => _ = ConnectivityCheckAsync(), null, ConnectivityInterval, ConnectivityInterval);
+        if (_keepAliveTimer is null)
+            _keepAliveTimer = new Timer(_ => _ = MaybeKeepAliveAsync(), null,
+                TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(30));
     }
 
     public void Stop()
@@ -231,7 +252,7 @@ public sealed class CloudSyncStatusModel : INotifyPropertyChanged
         }
     }
 
-    private static string BuildConnString(CloudCreds c)
+    private static string BuildConnString(CloudSyncCreds c)
     {
         var b = new NpgsqlConnectionStringBuilder
         {
@@ -246,25 +267,16 @@ public sealed class CloudSyncStatusModel : INotifyPropertyChanged
         return b.ConnectionString;
     }
 
-    private static CloudCreds? TryReadCreds()
+    private static CloudSyncCreds? TryReadCreds()
     {
-        try
-        {
-            if (!File.Exists(CredsPath)) return null;
-            var json = File.ReadAllText(CredsPath);
-            var c = JsonSerializer.Deserialize<CloudCreds>(json);
-            if (c is null) return null;
-            if (string.IsNullOrWhiteSpace(c.Host) || string.IsNullOrWhiteSpace(c.Database)
-                || string.IsNullOrWhiteSpace(c.Username) || string.IsNullOrWhiteSpace(c.Password))
-            {
-                return null;
-            }
-            return c;
-        }
-        catch
+        var c = CloudSyncCredsService.Load();
+        if (c is null) return null;
+        if (string.IsNullOrWhiteSpace(c.Host) || string.IsNullOrWhiteSpace(c.Database)
+            || string.IsNullOrWhiteSpace(c.Username) || string.IsNullOrWhiteSpace(c.Password))
         {
             return null;
         }
+        return c;
     }
 
     private void RaiseDerived()
@@ -294,13 +306,4 @@ public sealed class CloudSyncStatusModel : INotifyPropertyChanged
 
     private void OnPropertyChanged([CallerMemberName] string? name = null)
         => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-
-    private sealed class CloudCreds
-    {
-        public string Host { get; set; } = "";
-        public int Port { get; set; } = 6543;
-        public string Database { get; set; } = "postgres";
-        public string Username { get; set; } = "";
-        public string Password { get; set; } = "";
-    }
 }

--- a/Kasir.Avalonia/Infrastructure/CloudSyncStatusModel.cs
+++ b/Kasir.Avalonia/Infrastructure/CloudSyncStatusModel.cs
@@ -1,0 +1,306 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Media;
+using Kasir.Data;
+using Microsoft.Data.Sqlite;
+using Npgsql;
+
+namespace Kasir.Avalonia.Infrastructure;
+
+public enum CloudSyncState
+{
+    Disabled,
+    Waking,
+    Connected,
+    Queued,
+    Disconnected,
+    Error
+}
+
+public sealed class CloudSyncStatusModel : INotifyPropertyChanged
+{
+    private static readonly Lazy<CloudSyncStatusModel> _instance = new(() => new CloudSyncStatusModel());
+    public static CloudSyncStatusModel Current => _instance.Value;
+
+    private static readonly TimeSpan QueuePollInterval = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan ConnectivityInterval = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan WakeTimeout = TimeSpan.FromSeconds(90);
+
+    private static readonly string ConfigDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Kasir");
+    private static readonly string CredsPath = Path.Combine(ConfigDir, "cloudsync.json");
+
+    private CloudSyncState _state = CloudSyncState.Disabled;
+    private int _queueDepth;
+    private int _consecutiveFailures;
+    private DateTime _lastConnectivityCheck = DateTime.MinValue;
+    private DateTime _lastKeepAliveDate = DateTime.MinValue.Date;
+    private CloudCreds? _creds;
+
+    private Timer? _queueTimer;
+    private Timer? _connectivityTimer;
+    private Timer? _keepAliveTimer;
+
+    private int _connectivityInFlight;
+
+    private CloudSyncStatusModel() { }
+
+    public CloudSyncState State
+    {
+        get => _state;
+        private set
+        {
+            if (_state == value) return;
+            _state = value;
+            OnPropertyChanged();
+            RaiseDerived();
+        }
+    }
+
+    public int QueueDepth
+    {
+        get => _queueDepth;
+        private set
+        {
+            if (_queueDepth == value) return;
+            _queueDepth = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(DisplayText));
+        }
+    }
+
+    public string DisplayText => State switch
+    {
+        CloudSyncState.Disabled     => "Cloud · off",
+        CloudSyncState.Waking       => "Cloud · membangunkan…",
+        CloudSyncState.Connected    => "Cloud · OK",
+        CloudSyncState.Queued       => $"Cloud · {_queueDepth} antri",
+        CloudSyncState.Disconnected => "Cloud · offline",
+        CloudSyncState.Error        => "Cloud · gagal",
+        _                           => string.Empty
+    };
+
+    public bool ShowDot => State is CloudSyncState.Connected or CloudSyncState.Queued or CloudSyncState.Error;
+    public bool ShowSpinner => State == CloudSyncState.Waking;
+
+    public IBrush DotBrush => State switch
+    {
+        CloudSyncState.Connected    => ResolveBrush("SuccessBrush"),
+        CloudSyncState.Queued       => ResolveBrush("WarningBrush"),
+        CloudSyncState.Waking       => ResolveBrush("WarningBrush"),
+        CloudSyncState.Error        => ResolveBrush("DangerBrush"),
+        CloudSyncState.Disconnected => ResolveBrush("WarningBrush"),
+        _                           => ResolveBrush("FgDimBrush", "FgSecondaryBrush")
+    };
+
+    public IBrush TextBrush => State == CloudSyncState.Disabled
+        ? ResolveBrush("FgDimBrush", "FgSecondaryBrush")
+        : ResolveBrush("FgSecondaryBrush", "FgPrimaryBrush");
+
+    public void Start()
+    {
+        _creds = TryReadCreds();
+        if (_creds is null)
+        {
+            State = CloudSyncState.Disabled;
+            return;
+        }
+
+        State = CloudSyncState.Waking;
+        _ = WakeAsync();
+
+        _queueTimer = new Timer(_ => PollQueueDepth(), null, QueuePollInterval, QueuePollInterval);
+        _connectivityTimer = new Timer(_ => _ = ConnectivityCheckAsync(), null, ConnectivityInterval, ConnectivityInterval);
+        // Keep-alive: tick every 30 minutes, fire at 03:00 once per day.
+        _keepAliveTimer = new Timer(_ => _ = MaybeKeepAliveAsync(), null,
+            TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(30));
+    }
+
+    public void Stop()
+    {
+        _queueTimer?.Dispose();
+        _connectivityTimer?.Dispose();
+        _keepAliveTimer?.Dispose();
+        _queueTimer = _connectivityTimer = _keepAliveTimer = null;
+    }
+
+    private async Task WakeAsync()
+    {
+        var ok = await TrySelectOneAsync(WakeTimeout).ConfigureAwait(false);
+        PollQueueDepth();
+        if (ok)
+        {
+            _consecutiveFailures = 0;
+            _lastConnectivityCheck = DateTime.UtcNow;
+            State = _queueDepth > 0 ? CloudSyncState.Queued : CloudSyncState.Connected;
+        }
+        else
+        {
+            State = CloudSyncState.Disconnected;
+        }
+    }
+
+    private async Task ConnectivityCheckAsync()
+    {
+        if (_creds is null) return;
+        if (Interlocked.Exchange(ref _connectivityInFlight, 1) == 1) return;
+        try
+        {
+            var ok = await TrySelectOneAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+            _lastConnectivityCheck = DateTime.UtcNow;
+            if (ok)
+            {
+                _consecutiveFailures = 0;
+                if (State is CloudSyncState.Disconnected or CloudSyncState.Error or CloudSyncState.Waking)
+                {
+                    State = _queueDepth > 0 ? CloudSyncState.Queued : CloudSyncState.Connected;
+                }
+            }
+            else
+            {
+                _consecutiveFailures++;
+                State = _consecutiveFailures >= 3 ? CloudSyncState.Error : CloudSyncState.Disconnected;
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _connectivityInFlight, 0);
+        }
+    }
+
+    private async Task MaybeKeepAliveAsync()
+    {
+        if (_creds is null) return;
+        var now = DateTime.Now;
+        if (now.Hour != 3) return;
+        if (_lastKeepAliveDate == now.Date) return;
+        _lastKeepAliveDate = now.Date;
+        await TrySelectOneAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+    }
+
+    private async Task<bool> TrySelectOneAsync(TimeSpan timeout)
+    {
+        if (_creds is null) return false;
+        try
+        {
+            var connStr = BuildConnString(_creds);
+            using var cts = new CancellationTokenSource(timeout);
+            await using var conn = new NpgsqlConnection(connStr);
+            await conn.OpenAsync(cts.Token).ConfigureAwait(false);
+            await using var cmd = new NpgsqlCommand("SELECT 1", conn);
+            cmd.CommandTimeout = (int)Math.Max(1, timeout.TotalSeconds);
+            await cmd.ExecuteScalarAsync(cts.Token).ConfigureAwait(false);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void PollQueueDepth()
+    {
+        try
+        {
+            var conn = DbConnection.GetConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM sync_queue WHERE cloud_synced=0";
+            var result = cmd.ExecuteScalar();
+            var depth = result is null ? 0 : Convert.ToInt32(result);
+            QueueDepth = depth;
+            // Only flip Connected ↔ Queued; leave Waking/Disconnected/Error alone.
+            if (State is CloudSyncState.Connected or CloudSyncState.Queued)
+            {
+                State = depth > 0 ? CloudSyncState.Queued : CloudSyncState.Connected;
+            }
+        }
+        catch (SqliteException)
+        {
+            // sync_queue may not exist on first run — ignore.
+        }
+        catch
+        {
+            // Best-effort
+        }
+    }
+
+    private static string BuildConnString(CloudCreds c)
+    {
+        var b = new NpgsqlConnectionStringBuilder
+        {
+            Host = c.Host,
+            Port = c.Port,
+            Database = c.Database,
+            Username = c.Username,
+            Password = c.Password,
+            SslMode = SslMode.Require,
+            Timeout = 30
+        };
+        return b.ConnectionString;
+    }
+
+    private static CloudCreds? TryReadCreds()
+    {
+        try
+        {
+            if (!File.Exists(CredsPath)) return null;
+            var json = File.ReadAllText(CredsPath);
+            var c = JsonSerializer.Deserialize<CloudCreds>(json);
+            if (c is null) return null;
+            if (string.IsNullOrWhiteSpace(c.Host) || string.IsNullOrWhiteSpace(c.Database)
+                || string.IsNullOrWhiteSpace(c.Username) || string.IsNullOrWhiteSpace(c.Password))
+            {
+                return null;
+            }
+            return c;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void RaiseDerived()
+    {
+        OnPropertyChanged(nameof(DisplayText));
+        OnPropertyChanged(nameof(ShowDot));
+        OnPropertyChanged(nameof(ShowSpinner));
+        OnPropertyChanged(nameof(DotBrush));
+        OnPropertyChanged(nameof(TextBrush));
+    }
+
+    private static IBrush ResolveBrush(params string[] keys)
+    {
+        var app = Application.Current;
+        if (app is null) return Brushes.Gray;
+        foreach (var key in keys)
+        {
+            if (app.Resources.TryGetResource(key, app.ActualThemeVariant, out var res) && res is IBrush brush)
+            {
+                return brush;
+            }
+        }
+        return Brushes.Gray;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    private sealed class CloudCreds
+    {
+        public string Host { get; set; } = "";
+        public int Port { get; set; } = 6543;
+        public string Database { get; set; } = "postgres";
+        public string Username { get; set; } = "";
+        public string Password { get; set; } = "";
+    }
+}

--- a/Kasir.Avalonia/Infrastructure/PrinterStatusModel.cs
+++ b/Kasir.Avalonia/Infrastructure/PrinterStatusModel.cs
@@ -1,0 +1,139 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Avalonia;
+using Avalonia.Media;
+using Kasir.Hardware;
+
+namespace Kasir.Avalonia.Infrastructure;
+
+public enum PrinterState
+{
+    Connected,
+    Offline,
+    Error
+}
+
+public sealed class PrinterStatusModel : INotifyPropertyChanged
+{
+    private static readonly Lazy<PrinterStatusModel> _instance = new(() => new PrinterStatusModel());
+    public static PrinterStatusModel Current => _instance.Value;
+
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
+
+    private PrinterState _state = PrinterState.Offline;
+    private Timer? _timer;
+    private Func<IReceiptPrinter?>? _printerFactory;
+    private int _polling; // 0=idle, 1=in-flight
+
+    private PrinterStatusModel() { }
+
+    public PrinterState State
+    {
+        get => _state;
+        private set
+        {
+            if (_state == value) return;
+            _state = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(DisplayText));
+            OnPropertyChanged(nameof(ShowDot));
+            OnPropertyChanged(nameof(DotBrush));
+        }
+    }
+
+    public string DisplayText => State switch
+    {
+        PrinterState.Connected => "Printer ✓",
+        PrinterState.Offline   => "Printer offline",
+        PrinterState.Error     => "Printer error",
+        _                      => string.Empty
+    };
+
+    public bool ShowDot => State != PrinterState.Offline;
+
+    public IBrush DotBrush => State switch
+    {
+        PrinterState.Connected => ResolveBrush("SuccessBrush"),
+        PrinterState.Error     => ResolveBrush("DangerBrush"),
+        _                      => ResolveBrush("WarningBrush")
+    };
+
+    /// <summary>
+    /// Start the poll loop. Factory may return null when no printer is configured;
+    /// the model then reports Offline.
+    /// </summary>
+    public void Start(Func<IReceiptPrinter?> printerFactory)
+    {
+        _printerFactory = printerFactory ?? throw new ArgumentNullException(nameof(printerFactory));
+        _timer?.Dispose();
+        _timer = new Timer(_ => Poll(), null, TimeSpan.Zero, PollInterval);
+    }
+
+    public void Stop()
+    {
+        _timer?.Dispose();
+        _timer = null;
+    }
+
+    private void Poll()
+    {
+        if (Interlocked.Exchange(ref _polling, 1) == 1) return;
+        try
+        {
+            var factory = _printerFactory;
+            if (factory is null)
+            {
+                State = PrinterState.Offline;
+                return;
+            }
+
+            IReceiptPrinter? printer;
+            try
+            {
+                printer = factory();
+            }
+            catch
+            {
+                State = PrinterState.Error;
+                return;
+            }
+
+            if (printer is null)
+            {
+                // TODO: wire to runtime printer config; currently always reports Offline
+                State = PrinterState.Offline;
+                return;
+            }
+
+            try
+            {
+                State = printer.IsAvailable() ? PrinterState.Connected : PrinterState.Offline;
+            }
+            catch
+            {
+                State = PrinterState.Error;
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _polling, 0);
+        }
+    }
+
+    private static IBrush ResolveBrush(string key)
+    {
+        var app = Application.Current;
+        if (app is not null && app.Resources.TryGetResource(key, app.ActualThemeVariant, out var res) && res is IBrush brush)
+        {
+            return brush;
+        }
+        return Brushes.Gray;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/Kasir.Avalonia/Infrastructure/UpdateStatusModel.cs
+++ b/Kasir.Avalonia/Infrastructure/UpdateStatusModel.cs
@@ -1,0 +1,208 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Media;
+using Kasir.Data;
+using Kasir.Services;
+using Kasir.Utils;
+
+namespace Kasir.Avalonia.Infrastructure;
+
+public enum UpdateAvailability
+{
+    Current,
+    UpdateAvailable,
+    Updating
+}
+
+public sealed class UpdateStatusModel : INotifyPropertyChanged
+{
+    private static readonly Lazy<UpdateStatusModel> _instance = new(() => new UpdateStatusModel());
+    public static UpdateStatusModel Current => _instance.Value;
+
+    private static readonly TimeSpan CheckEvery = TimeSpan.FromHours(24);
+    private static readonly TimeSpan TickInterval = TimeSpan.FromHours(1);
+
+    private static readonly string ConfigDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Kasir");
+    private static readonly string StatePath = Path.Combine(ConfigDir, "update-state.json");
+
+    private UpdateAvailability _state = UpdateAvailability.Current;
+    private string _currentVersion = AppVersion.Current;
+    private string? _newVersion;
+    private DateTime? _lastCheckAt;
+    private Timer? _timer;
+    private int _checking; // 0=idle, 1=in-flight
+
+    private UpdateStatusModel() { }
+
+    public UpdateAvailability State
+    {
+        get => _state;
+        private set
+        {
+            if (_state == value) return;
+            _state = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(DisplayText));
+            OnPropertyChanged(nameof(ShowDot));
+            OnPropertyChanged(nameof(ShowSpinner));
+            OnPropertyChanged(nameof(DotBrush));
+            OnPropertyChanged(nameof(TextBrush));
+        }
+    }
+
+    public string DisplayText => State switch
+    {
+        UpdateAvailability.Current         => $"v{_currentVersion}",
+        UpdateAvailability.UpdateAvailable => $"v{_currentVersion} → v{_newVersion}",
+        UpdateAvailability.Updating        => "Memperbarui…",
+        _                                  => string.Empty
+    };
+
+    public bool ShowDot => State == UpdateAvailability.UpdateAvailable;
+    public bool ShowSpinner => State == UpdateAvailability.Updating;
+
+    public IBrush DotBrush => State switch
+    {
+        UpdateAvailability.UpdateAvailable => ResolveBrush("BrandBrush", "AccentBrush", "SuccessBrush"),
+        UpdateAvailability.Updating        => ResolveBrush("WarningBrush"),
+        _                                  => ResolveBrush("FgDimBrush", "FgSecondaryBrush")
+    };
+
+    public IBrush TextBrush => State switch
+    {
+        UpdateAvailability.Current => ResolveBrush("FgDimBrush", "FgSecondaryBrush"),
+        _                          => ResolveBrush("FgPrimaryBrush", "FgSecondaryBrush")
+    };
+
+    public void Start()
+    {
+        ReadState();
+        _timer?.Dispose();
+        // Tick immediately, then hourly. The handler decides whether to actually hit the network.
+        _timer = new Timer(_ => Tick(), null, TimeSpan.Zero, TickInterval);
+    }
+
+    public void Stop()
+    {
+        _timer?.Dispose();
+        _timer = null;
+    }
+
+    public void MarkUpdating() => State = UpdateAvailability.Updating;
+
+    private void Tick()
+    {
+        if (_lastCheckAt is { } last && DateTime.UtcNow - last < CheckEvery)
+        {
+            return;
+        }
+        _ = RunCheckAsync();
+    }
+
+    private async Task RunCheckAsync()
+    {
+        if (Interlocked.Exchange(ref _checking, 1) == 1) return;
+        try
+        {
+            UpdateCheckResult? result = null;
+            try
+            {
+                var svc = new UpdateService(DbConnection.GetConnection());
+                result = await svc.CheckForUpdateAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort; keep last known state.
+            }
+
+            if (result is not null && string.IsNullOrEmpty(result.Error))
+            {
+                if (result.Available && !string.IsNullOrEmpty(result.NewVersion))
+                {
+                    _newVersion = result.NewVersion;
+                    State = UpdateAvailability.UpdateAvailable;
+                }
+                else if (State != UpdateAvailability.Updating)
+                {
+                    _newVersion = null;
+                    State = UpdateAvailability.Current;
+                }
+            }
+
+            _lastCheckAt = DateTime.UtcNow;
+            WriteState();
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _checking, 0);
+        }
+    }
+
+    private void ReadState()
+    {
+        try
+        {
+            if (!File.Exists(StatePath)) return;
+            var json = File.ReadAllText(StatePath);
+            var s = JsonSerializer.Deserialize<PersistedState>(json);
+            if (s is null) return;
+            if (DateTime.TryParse(s.LastCheckAt, out var dt))
+            {
+                _lastCheckAt = dt.ToUniversalTime();
+            }
+        }
+        catch
+        {
+            // Best-effort
+        }
+    }
+
+    private void WriteState()
+    {
+        try
+        {
+            Directory.CreateDirectory(ConfigDir);
+            var s = new PersistedState
+            {
+                LastCheckAt = (_lastCheckAt ?? DateTime.UtcNow).ToString("o")
+            };
+            File.WriteAllText(StatePath, JsonSerializer.Serialize(s));
+        }
+        catch
+        {
+            // Best-effort
+        }
+    }
+
+    private static IBrush ResolveBrush(params string[] keys)
+    {
+        var app = Application.Current;
+        if (app is null) return Brushes.Gray;
+        foreach (var key in keys)
+        {
+            if (app.Resources.TryGetResource(key, app.ActualThemeVariant, out var res) && res is IBrush brush)
+            {
+                return brush;
+            }
+        }
+        return Brushes.Gray;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    private sealed class PersistedState
+    {
+        public string? LastCheckAt { get; set; }
+    }
+}

--- a/Kasir.Avalonia/Kasir.Avalonia.csproj
+++ b/Kasir.Avalonia/Kasir.Avalonia.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
     <PackageReference Include="Lucide.Avalonia" Version="0.2.5" />
+    <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>

--- a/Kasir.Avalonia/ShellWindow.axaml
+++ b/Kasir.Avalonia/ShellWindow.axaml
@@ -15,7 +15,23 @@
             BorderBrush="{DynamicResource BorderSubtleBrush}"
             BorderThickness="0,1,0,0"
             Padding="12,4">
-      <StackPanel Orientation="Horizontal">
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <Border x:Name="PrinterBadge"
+                Background="{DynamicResource BgSelectedBrush}"
+                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                BorderThickness="1"
+                CornerRadius="999"
+                Padding="8,2"
+                VerticalAlignment="Center">
+          <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+            <Ellipse x:Name="PrinterDot" Width="6" Height="6" Fill="{DynamicResource WarningBrush}"/>
+            <TextBlock x:Name="PrinterText"
+                       Text="Printer offline"
+                       FontSize="{DynamicResource FontSizeXs}"
+                       Foreground="{DynamicResource FgSecondaryBrush}"/>
+          </StackPanel>
+        </Border>
+
         <Border x:Name="SyncBadge"
                 Background="{DynamicResource BgSelectedBrush}"
                 BorderBrush="{DynamicResource BorderSubtleBrush}"
@@ -30,6 +46,44 @@
                                Foreground="{DynamicResource FgSecondaryBrush}"/>
             <TextBlock x:Name="SyncText"
                        Text="Online · Sync 0d lalu"
+                       FontSize="{DynamicResource FontSizeXs}"
+                       Foreground="{DynamicResource FgSecondaryBrush}"/>
+          </StackPanel>
+        </Border>
+
+        <Border x:Name="CloudBadge"
+                Background="{DynamicResource BgSelectedBrush}"
+                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                BorderThickness="1"
+                CornerRadius="999"
+                Padding="8,2"
+                VerticalAlignment="Center">
+          <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+            <Ellipse x:Name="CloudDot" Width="6" Height="6" Fill="{DynamicResource FgSecondaryBrush}" IsVisible="False"/>
+            <lucide:LucideIcon x:Name="CloudSpinner" Kind="RefreshCw" Size="10"
+                               IsVisible="False"
+                               Foreground="{DynamicResource FgSecondaryBrush}"/>
+            <TextBlock x:Name="CloudText"
+                       Text="Cloud · off"
+                       FontSize="{DynamicResource FontSizeXs}"
+                       Foreground="{DynamicResource FgSecondaryBrush}"/>
+          </StackPanel>
+        </Border>
+
+        <Border x:Name="VersionBadge"
+                Background="{DynamicResource BgSelectedBrush}"
+                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                BorderThickness="1"
+                CornerRadius="999"
+                Padding="8,2"
+                VerticalAlignment="Center">
+          <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+            <Ellipse x:Name="VersionDot" Width="6" Height="6" Fill="{DynamicResource FgSecondaryBrush}" IsVisible="False"/>
+            <lucide:LucideIcon x:Name="VersionSpinner" Kind="RefreshCw" Size="10"
+                               IsVisible="False"
+                               Foreground="{DynamicResource FgSecondaryBrush}"/>
+            <TextBlock x:Name="VersionText"
+                       Text="v0.0.0"
                        FontSize="{DynamicResource FontSizeXs}"
                        Foreground="{DynamicResource FgSecondaryBrush}"/>
           </StackPanel>

--- a/Kasir.Avalonia/ShellWindow.axaml.cs
+++ b/Kasir.Avalonia/ShellWindow.axaml.cs
@@ -29,7 +29,13 @@ public partial class ShellWindow : Window
         NavigationService.Initialize(this, ContentArea);
         UpdateThemeIcon();
         SyncStatusModel.Current.PropertyChanged += OnSyncStatusChanged;
+        PrinterStatusModel.Current.PropertyChanged += OnPrinterStatusChanged;
+        UpdateStatusModel.Current.PropertyChanged += OnUpdateStatusChanged;
+        CloudSyncStatusModel.Current.PropertyChanged += OnCloudStatusChanged;
         UpdateSyncBadge();
+        UpdatePrinterBadge();
+        UpdateVersionBadge();
+        UpdateCloudBadge();
     }
 
     public void ShowOverlay(Control content)
@@ -74,6 +80,52 @@ public partial class ShellWindow : Window
     private void OnSyncStatusChanged(object? sender, PropertyChangedEventArgs e)
     {
         Dispatcher.UIThread.Post(UpdateSyncBadge);
+    }
+
+    private void OnPrinterStatusChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(UpdatePrinterBadge);
+    }
+
+    private void OnUpdateStatusChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(UpdateVersionBadge);
+    }
+
+    private void OnCloudStatusChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(UpdateCloudBadge);
+    }
+
+    private void UpdatePrinterBadge()
+    {
+        if (PrinterText is null || PrinterDot is null) return;
+        var m = PrinterStatusModel.Current;
+        PrinterText.Text = m.DisplayText;
+        PrinterDot.IsVisible = m.ShowDot;
+        if (m.ShowDot) PrinterDot.Fill = m.DotBrush;
+    }
+
+    private void UpdateVersionBadge()
+    {
+        if (VersionText is null || VersionDot is null || VersionSpinner is null) return;
+        var m = UpdateStatusModel.Current;
+        VersionText.Text = m.DisplayText;
+        VersionText.Foreground = m.TextBrush;
+        VersionSpinner.IsVisible = m.ShowSpinner;
+        VersionDot.IsVisible = m.ShowDot;
+        if (m.ShowDot) VersionDot.Fill = m.DotBrush;
+    }
+
+    private void UpdateCloudBadge()
+    {
+        if (CloudText is null || CloudDot is null || CloudSpinner is null) return;
+        var m = CloudSyncStatusModel.Current;
+        CloudText.Text = m.DisplayText;
+        CloudText.Foreground = m.TextBrush;
+        CloudSpinner.IsVisible = m.ShowSpinner;
+        CloudDot.IsVisible = m.ShowDot;
+        if (m.ShowDot) CloudDot.Fill = m.DotBrush;
     }
 
     private void UpdateSyncBadge()

--- a/Kasir.CloudSync/Program.cs
+++ b/Kasir.CloudSync/Program.cs
@@ -32,6 +32,23 @@ namespace Kasir.CloudSync
                     cfg.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
                     cfg.AddEnvironmentVariables(prefix: "KASIR_CLOUDSYNC_");
                     cfg.AddCommandLine(args);
+
+                    // Fallback: read the in-app creds JSON written by
+                    // CloudSyncSetupView (LocalAppData/Kasir/cloudsync.json).
+                    // Lowest priority — only fills CloudSync:SupabaseConnectionString
+                    // if no other source provided one.
+                    var credsConn = TryBuildConnFromCredsJson();
+                    if (!string.IsNullOrWhiteSpace(credsConn))
+                    {
+                        var built = cfg.Build();
+                        if (string.IsNullOrWhiteSpace(built["CloudSync:SupabaseConnectionString"]))
+                        {
+                            cfg.AddInMemoryCollection(new System.Collections.Generic.Dictionary<string, string>
+                            {
+                                ["CloudSync:SupabaseConnectionString"] = credsConn,
+                            });
+                        }
+                    }
                 })
                 .ConfigureServices((ctx, services) =>
                 {
@@ -70,6 +87,11 @@ namespace Kasir.CloudSync
         var configuration = cfgBuilder.Build();
         var conn = configuration["CloudSync:SupabaseConnectionString"]
                    ?? Environment.GetEnvironmentVariable("KASIR_CLOUDSYNC_SUPABASE");
+        if (string.IsNullOrWhiteSpace(conn))
+        {
+            var fromCreds = TryBuildConnFromCredsJson();
+            if (!string.IsNullOrWhiteSpace(fromCreds)) conn = fromCreds;
+        }
         var dbPath = configuration["CloudSync:KasirDbPath"]
                    ?? Environment.GetEnvironmentVariable("KASIR_CLOUDSYNC_DBPATH");
         if (string.IsNullOrWhiteSpace(conn) || string.IsNullOrWhiteSpace(dbPath))
@@ -100,6 +122,41 @@ namespace Kasir.CloudSync
             foreach (var a in args)
                 if (string.Equals(a, flag, StringComparison.OrdinalIgnoreCase)) return true;
             return false;
+        }
+
+        // Reads the in-app creds JSON (LocalAppData/Kasir/cloudsync.json on Windows;
+        // ~/Library/Application Support/Kasir/cloudsync.json on macOS) and builds
+        // a Postgres connection string. Returns null if the file is absent,
+        // unreadable, or has empty fields. Used as the lowest-priority config
+        // source so the in-app setup screen can configure the worker without
+        // touching appsettings.json.
+        internal static string TryBuildConnFromCredsJson()
+        {
+            try
+            {
+                var path = System.IO.Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "Kasir",
+                    "cloudsync.json");
+                if (!System.IO.File.Exists(path)) return "";
+                using var doc = System.Text.Json.JsonDocument.Parse(System.IO.File.ReadAllText(path));
+                var root = doc.RootElement;
+                string Get(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == System.Text.Json.JsonValueKind.String ? v.GetString() ?? "" : "";
+                int GetInt(string k, int dflt) => root.TryGetProperty(k, out var v) && v.ValueKind == System.Text.Json.JsonValueKind.Number ? v.GetInt32() : dflt;
+                var host = Get("Host");
+                var db = Get("Database");
+                var user = Get("Username");
+                var pwd = Get("Password");
+                var port = GetInt("Port", 6543);
+                if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(db)
+                    || string.IsNullOrWhiteSpace(user) || string.IsNullOrWhiteSpace(pwd))
+                    return "";
+                return $"Host={host};Port={port};Database={db};Username={user};Password={pwd};SslMode=Require";
+            }
+            catch
+            {
+                return "";
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,28 @@ On first run a setup dialog appears — choose **Seed** for a fresh database or 
 dotnet test Kasir.Core.Tests/Kasir.Core.Tests.csproj
 ```
 
+## Development on macOS / Linux
+
+The cloud sync worker runs as a separate process. Two terminals:
+
+**Terminal 1 — POS UI**
+
+```bash
+dotnet run --project Kasir.Avalonia
+```
+
+**Terminal 2 — Cloud sync worker** (only needed if you want to test cloud push)
+
+```bash
+dotnet run --project Kasir.CloudSync
+```
+
+The worker reads creds from `~/Library/Application Support/Kasir/cloudsync.json` (macOS) or `%LocalAppData%\Kasir\cloudsync.json` (Windows). Configure via in-app screen: F8 Admin → Cloud Sync.
+
+## Production deployment (Windows 10 gateway)
+
+See `docs/NEXT-STEPS.md` for the NSSM-wrapped service deployment.
+
 ### Deploy to Windows Register
 
 ```bash


### PR DESCRIPTION
## Summary
Adds three status badges to the ShellWindow status bar (Printer, Cloud Sync, App Version), reusing the existing SyncBadge styling. Order: Printer · LAN Sync · Cloud Sync · Version.

- **CS-1 PrinterStatusModel**: singleton polling `IReceiptPrinter.IsAvailable()` every 30s; states Connected/Offline/Error with Indonesian copy (`Printer ✓` / `Printer offline` / `Printer error`).
- **CS-2 UpdateStatusModel**: wraps existing `UpdateService.CheckForUpdateAsync` once per 24h, persists `last_check_at` to `LocalAppData/Kasir/update-state.json` (mirrors ThemeService pattern). States Current / UpdateAvailable / Updating.
- **CS-3 CloudSyncStatusModel**: reads creds from `LocalAppData/Kasir/cloudsync.json`. On startup: `Waking` → `SELECT 1` via Npgsql (90s timeout) → `Connected` or `Disconnected`. Every 60s polls local `sync_queue` for `cloud_synced=0` count → flips Connected ↔ Queued. Every 5 min re-checks Supabase connectivity (3 consecutive failures → Error). Daily 03:00 keep-alive `SELECT 1` (best-effort).

Adds `Npgsql 9.0.2` to `Kasir.Avalonia.csproj`. No changes to `Kasir.CloudSync`, `CloudSyncSetupView`, or `CloudSyncCredsService` (deferred to CS-4/CS-5).

## Test plan
- [x] `dotnet build` clean — 7 projects, 0 errors, 0 warnings
- [x] `dotnet test` — Core 333 / Avalonia 6 / CloudSync 38 = 377 passing
- [x] 8s smoke run — `[PERF] app_startup PASS`, no startup crash
- [ ] Manual visual check on Windows hardware (deferred to physical hardware test)