### PR TITLE
feat(release): matrix-build 3 per-register ZIPs with baked help.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
     permissions:
       contents: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        register: ['01', '02', '03']
+
     steps:
     - uses: actions/checkout@v4
 
@@ -36,23 +41,49 @@ jobs:
       run: dotnet build Kasir.Avalonia.slnx -c Release
 
     - name: Test
+      if: matrix.register == '01'
       run: dotnet test Kasir.Core.Tests/Kasir.Core.Tests.csproj -c Release --no-build
 
     - name: Publish win-x64 self-contained
-      run: dotnet publish Kasir.Avalonia/Kasir.Avalonia.csproj -c Release -r win-x64 --self-contained -o publish/win-x64
+      run: dotnet publish Kasir.Avalonia/Kasir.Avalonia.csproj -c Release -r win-x64 --self-contained -o publish/win-x64-${{ matrix.register }}
+
+    - name: Write help.json (per-register machine credentials)
+      shell: pwsh
+      env:
+        SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+        SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        MACHINE_EMAIL: ${{ secrets[format('REGISTER_{0}_EMAIL', matrix.register)] }}
+        MACHINE_PASSWORD: ${{ secrets[format('REGISTER_{0}_PASSWORD', matrix.register)] }}
+      run: |
+        $releaseDir = "publish/win-x64-${{ matrix.register }}"
+        if ([string]::IsNullOrEmpty($env:MACHINE_EMAIL) -or [string]::IsNullOrEmpty($env:MACHINE_PASSWORD)) {
+          Write-Error "Missing REGISTER_${{ matrix.register }}_EMAIL or PASSWORD secret"
+          exit 1
+        }
+        $helpConfig = @{
+          SupabaseUrl     = $env:SUPABASE_URL
+          AnonKey         = $env:SUPABASE_ANON_KEY
+          MachineEmail    = $env:MACHINE_EMAIL
+          MachinePassword = $env:MACHINE_PASSWORD
+          StoreId         = "sinar-makmur"
+          RegisterId      = "${{ matrix.register }}"
+        }
+        $json = $helpConfig | ConvertTo-Json -Depth 3
+        # Drop into the publish dir; the installer copies this to %APPDATA%\Kasir\help.json on first run.
+        # Keeping it next to Kasir.Avalonia.exe avoids needing extra installer logic.
+        [System.IO.File]::WriteAllText("$releaseDir/help.json", $json, [System.Text.Encoding]::UTF8)
+        Write-Host "help.json written for register ${{ matrix.register }} (email: $env:MACHINE_EMAIL)"
 
     - name: Prepare release directory
       shell: pwsh
       run: |
-        $releaseDir = "publish/win-x64"
-
-        # Write version.txt
+        $releaseDir = "publish/win-x64-${{ matrix.register }}"
         "${{ steps.version.outputs.VERSION }}" | Set-Content "$releaseDir/version.txt" -NoNewline
 
     - name: Generate checksums
       shell: pwsh
       run: |
-        $releaseDir = "publish/win-x64"
+        $releaseDir = "publish/win-x64-${{ matrix.register }}"
         $checksumLines = @()
 
         Get-ChildItem $releaseDir -Recurse -File |
@@ -72,7 +103,7 @@ jobs:
       env:
         SYNC_HMAC_KEY: ${{ secrets.SYNC_HMAC_KEY }}
       run: |
-        $releaseDir = "publish/win-x64"
+        $releaseDir = "publish/win-x64-${{ matrix.register }}"
         $checksumContent = Get-Content "$releaseDir/checksum.sha256" -Raw
 
         if ([string]::IsNullOrEmpty($env:SYNC_HMAC_KEY)) {
@@ -91,21 +122,29 @@ jobs:
     - name: Create release ZIP
       shell: pwsh
       run: |
-        Push-Location "publish/win-x64"
-        Compress-Archive -Path "*" -DestinationPath "../../kasir-${{ steps.version.outputs.VERSION }}.zip"
+        Push-Location "publish/win-x64-${{ matrix.register }}"
+        Compress-Archive -Path "*" -DestinationPath "../../kasir-${{ steps.version.outputs.VERSION }}-register-${{ matrix.register }}.zip"
         Pop-Location
 
-    - name: Create GitHub Release
+    - name: Upload to GitHub Release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.version.outputs.TAG }}
         files: |
-          kasir-${{ steps.version.outputs.VERSION }}.zip
+          kasir-${{ steps.version.outputs.VERSION }}-register-${{ matrix.register }}.zip
         generate_release_notes: false
         body: |
           ## Cara Install (Windows)
 
-          1. Download file `kasir-${{ steps.version.outputs.VERSION }}.zip` di bawah
+          **PENTING:** ada 3 file ZIP berbeda. Setiap register harus pakai file yang sesuai nomornya.
+
+          | Register | File |
+          |----------|------|
+          | Register 01 | `kasir-${{ steps.version.outputs.VERSION }}-register-01.zip` |
+          | Register 02 | `kasir-${{ steps.version.outputs.VERSION }}-register-02.zip` |
+          | Register 03 | `kasir-${{ steps.version.outputs.VERSION }}-register-03.zip` |
+
+          1. Download file ZIP sesuai nomor register
           2. Klik kanan → **Extract All** → pilih folder tujuan (misal: `C:\Kasir`)
           3. Buka folder hasil ekstrak → double-click **`Kasir.Avalonia.exe`**
           4. Tidak perlu install .NET atau software tambahan
@@ -113,14 +152,28 @@ jobs:
           > **Upgrade dari versi lama?**
           > Ekstrak ke folder yang sama, timpa file lama. Data (`kasir.db`) tidak akan tertimpa.
 
+          > **Salah download nomor register?**
+          > Fitur Bantuan akan terdaftar dengan ID register yang salah. Hapus folder, download ulang yang benar.
+
           ---
 
           ## Installation (English)
 
-          1. Download `kasir-${{ steps.version.outputs.VERSION }}.zip` below
+          **IMPORTANT:** there are 3 different ZIP files. Each register MUST use the file matching its number.
+
+          | Register | File |
+          |----------|------|
+          | Register 01 | `kasir-${{ steps.version.outputs.VERSION }}-register-01.zip` |
+          | Register 02 | `kasir-${{ steps.version.outputs.VERSION }}-register-02.zip` |
+          | Register 03 | `kasir-${{ steps.version.outputs.VERSION }}-register-03.zip` |
+
+          1. Download the ZIP matching your register number
           2. Right-click → **Extract All** → choose a destination folder (e.g. `C:\Kasir`)
           3. Open the extracted folder → double-click **`Kasir.Avalonia.exe`**
           4. No .NET runtime or additional software required — everything is bundled
 
           > **Upgrading from an older version?**
           > Extract into the same folder and overwrite existing files. Your database (`kasir.db`) will not be affected.
+
+          > **Downloaded the wrong register number?**
+          > The Bantuan help feature will register tickets under the wrong register ID. Delete the folder and re-download the correct one.

--- a/Kasir.Core/Help/Auth/HelpConfig.cs
+++ b/Kasir.Core/Help/Auth/HelpConfig.cs
@@ -24,13 +24,17 @@ namespace Kasir.Help.Auth
         /// Load HelpConfig from disk. Returns null when the file is missing,
         /// unreadable, or malformed. NEVER throws — caller treats null as
         /// "Bantuan operates in offline-only mode" (graceful degradation).
+        ///
+        /// Search order:
+        ///   1. %APPDATA%\Kasir\help.json (or ~/.kasir/help.json on non-Windows) — operator override
+        ///   2. {exe directory}/help.json — per-register baked into release ZIP
         /// </summary>
         public static HelpConfig? TryLoad()
         {
             try
             {
-                string path = ResolvePath();
-                if (!File.Exists(path)) return null;
+                string? path = ResolveExistingPath();
+                if (path is null) return null;
 
                 string raw = File.ReadAllText(path);
                 using var doc = JsonDocument.Parse(raw);
@@ -63,6 +67,7 @@ namespace Kasir.Help.Auth
 
         /// <summary>
         /// %APPDATA%\Kasir\help.json on Windows; ~/.kasir/help.json otherwise.
+        /// This is the OPERATOR OVERRIDE path — wins over the baked-in copy if present.
         /// </summary>
         public static string ResolvePath()
         {
@@ -73,6 +78,28 @@ namespace Kasir.Help.Auth
             }
             string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             return Path.Combine(home, ".kasir", "help.json");
+        }
+
+        /// <summary>
+        /// Path next to the running executable. Used by the release ZIP build —
+        /// release.yml writes per-register help.json into the publish dir so each
+        /// register's binary ships with its own machine credentials.
+        /// </summary>
+        public static string ResolveExePath()
+        {
+            return Path.Combine(AppContext.BaseDirectory, "help.json");
+        }
+
+        /// <summary>
+        /// Returns the first existing path from the search order, or null.
+        /// </summary>
+        private static string? ResolveExistingPath()
+        {
+            string overridePath = ResolvePath();
+            if (File.Exists(overridePath)) return overridePath;
+            string exePath = ResolveExePath();
+            if (File.Exists(exePath)) return exePath;
+            return null;
         }
 
         private static string ReadString(JsonElement root, string name)


### PR DESCRIPTION
## Why

Bantuan auth needs per-register credentials so the JWT carries a unique `register_id` (used for rate limiting + ticket audit). Manually dropping `help.json` on each Win7 register is fragile and error-prone — this bakes credentials into the release ZIP via GitHub Actions secrets.

## What changed

### `.github/workflows/release.yml`
- Matrix strategy on `register: [01, 02, 03]` → 3 ZIPs per release
- New step "Write help.json (per-register machine credentials)" reads matrix-scoped secrets via `secrets[format('REGISTER_{0}_EMAIL', matrix.register)]` and writes `help.json` next to `Kasir.Avalonia.exe` in the publish dir
- Test step gated to `matrix.register == '01'` so tests run once, not 3×
- Output ZIP renamed `kasir-{version}-register-{NN}.zip`
- Release body updated (Bahasa Indonesia + English) with per-register download table and a warning about wrong-zip-wrong-register

### `Kasir.Core/Help/Auth/HelpConfig.cs`
- New `ResolveExePath()` → returns `{AppContext.BaseDirectory}/help.json`
- New `ResolveExistingPath()` → checks `%APPDATA%\Kasir\help.json` first (operator override), falls back to exe-dir copy
- `TryLoad()` uses the new resolver — backward-compatible with existing manual `%APPDATA%` setups

## Required GitHub Secrets (kasir-pos repo)

Already set:

| Secret | Source |
|---|---|
| `REGISTER_01_EMAIL` / `REGISTER_01_PASSWORD` | Supabase machine user, register 01 |
| `REGISTER_02_EMAIL` / `REGISTER_02_PASSWORD` | Supabase machine user, register 02 |
| `REGISTER_03_EMAIL` / `REGISTER_03_PASSWORD` | Supabase machine user, register 03 |
| `SUPABASE_URL` | `https://mnatezzsysmadvrosnad.supabase.co` |
| `SUPABASE_ANON_KEY` | Project anon key |

## Test plan

- [x] `dotnet build Kasir.Core` — 0 errors, 1 pre-existing CS8632 warning (unrelated)
- [x] `dotnet test Kasir.Core.Tests` — 384/384 passing
- [ ] Cut a test release tag (e.g. `v2.6.0-rc1`) and confirm 3 ZIPs appear in the GitHub Release page
- [ ] Download `register-01.zip`, extract on a Win7 (or VM), launch, verify Bantuan TANYA round-trips a query

## Rollback

Revert PR. Existing manual `%APPDATA%\Kasir\help.json` deployments still work — `ResolveExistingPath()` checks `%APPDATA%` first.

## Follow-ups

- Add `git secrets` or similar pre-commit guard to make sure raw machine passwords never land in a future commit
- If a register loses its credentials (zip mismatch, accidental delete), re-issue by:
  1. Delete user via Supabase Auth dashboard
  2. Re-create with same `register_id` claim
  3. Update the matching GitHub secret
  4. Cut a new release
