### PR TITLE
fix(sync): map transaction tables to journal_no key column (F04)

### DIFF
--- a/Kasir.Core.Tests/Sync/PullServiceTests.cs
+++ b/Kasir.Core.Tests/Sync/PullServiceTests.cs
@@ -161,6 +161,58 @@ namespace Kasir.Tests.Sync
             result.AppliedCount.Should().Be(0);
         }
 
+        [Test]
+        public void Pull_ApplyUpdate_FindsRow_ByJournalNo()
+        {
+            // F04 pull side: ApplyUpdate builds WHERE [keycol] = @key via
+            // PushService.GetKeyColumn. Pre-fix that was WHERE [id] = <journal_no>
+            // (TEXT vs INTEGER PK, 0 rows). Post-fix it is WHERE [journal_no] = @key.
+            using (var cmd = _db.CreateCommand())
+            {
+                cmd.CommandText = @"
+                    INSERT INTO sales (doc_type, journal_no, doc_date, period_code, register_id, total_value)
+                    VALUES ('SALE', 'KLR01-2607-0001', '2026-07-07', '202607', '01', 100000);";
+                cmd.ExecuteNonQuery();
+            }
+
+            var batch = new SyncBatch
+            {
+                RegisterId = "01",
+                SchemaVersion = SyncConfig.SchemaVersion,
+                Timestamp = "2026-07-07 10:00:00",
+                BatchId = "f04pull01"
+            };
+            var evt = new SyncEvent
+            {
+                QueueId = 1,
+                TableName = "sales",
+                RecordKey = "KLR01-2607-0001",
+                Operation = "U"
+            };
+            // Omit the surrogate 'id' (that is F24's scope). Sync the business key
+            // plus the changed column.
+            evt.Data["journal_no"] = "KLR01-2607-0001";
+            evt.Data["doc_type"] = "SALE";
+            evt.Data["doc_date"] = "2026-07-07";
+            evt.Data["period_code"] = "202607";
+            evt.Data["total_value"] = 999999;
+            batch.Events.Add(evt);
+
+            string json = SignAndSerialize(batch);
+            _fileReader.Files["C:\\kasir\\sync\\outbox\\01_20260707_100000_f04pull01.json"] = json;
+
+            var result = _pullService.Pull();
+            result.AppliedCount.Should().Be(1);
+
+            using (var cmd = _db.CreateCommand())
+            {
+                cmd.CommandText = "SELECT total_value FROM sales WHERE journal_no = @j";
+                cmd.Parameters.AddWithValue("@j", "KLR01-2607-0001");
+                var total = Convert.ToInt64(cmd.ExecuteScalar());
+                total.Should().Be(999999, "ApplyUpdate must find the row by journal_no (F04)");
+            }
+        }
+
         private SyncBatch CreateValidBatch(string registerId)
         {
             var batch = new SyncBatch

--- a/Kasir.Core.Tests/Sync/PushServiceKeyColumnTests.cs
+++ b/Kasir.Core.Tests/Sync/PushServiceKeyColumnTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using FluentAssertions;
+using Kasir.Data.Repositories;
+using Kasir.Sync;
+using Kasir.Tests.TestHelpers;
+using Kasir.Tests.TestHelpers.Fakes;
+
+namespace Kasir.Tests.Sync
+{
+    // F04 — transaction-table sync events were silently dropped. The AFTER-INSERT
+    // triggers enqueue record_key = NEW.journal_no, but PushService.GetKeyColumn
+    // mapped the 7 transaction tables to "id", so FetchRowData ran
+    // WHERE [id] = <journal_no> (TEXT vs INTEGER PK), matched nothing, and Push()
+    // marked every entry synced anyway. These tests pin the fix:
+    //   1. a sale must serialize into the batch, fetched by journal_no (not id); and
+    //   2. an entry whose row cannot be fetched must be marked failed (visible),
+    //      not silently synced.
+    [TestFixture]
+    public class PushServiceKeyColumnTests
+    {
+        private SqliteConnection _db;
+        private FakeSyncFileWriter _fileWriter;
+        private FakeClock _clock;
+        private PushService _push;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _db = TestDb.Create();
+            _fileWriter = new FakeSyncFileWriter();
+            _clock = new FakeClock(new DateTime(2026, 7, 7, 10, 0, 0));
+
+            var cfg = new ConfigRepository(_db);
+            cfg.Set("register_id", "01");
+            cfg.Set("sync_hub_share", "C:\\kasir\\sync");
+            cfg.Set("sync_hmac_key", "test-secret-key-32bytes!!");
+
+            _push = new PushService(_db, _fileWriter, _clock);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _db?.Close();
+            _db?.Dispose();
+        }
+
+        [Test]
+        public void Push_RoundTripsSaleByJournalNo_NotById()
+        {
+            // Insert a sale. trg_sales_sync_i enqueues record_key = NEW.journal_no.
+            using (var cmd = _db.CreateCommand())
+            {
+                cmd.CommandText = @"
+                    INSERT INTO sales (doc_type, journal_no, doc_date, period_code, register_id, total_value)
+                    VALUES ('SALE', 'KLR01-2607-0001', '2026-07-07', '202607', '01', 50000);";
+                cmd.ExecuteNonQuery();
+            }
+
+            // The trigger must have enqueued the journal_no as record_key (not the id).
+            using (var cmd = _db.CreateCommand())
+            {
+                cmd.CommandText = "SELECT record_key FROM sync_queue WHERE table_name = 'sales'";
+                var recordKey = (string)cmd.ExecuteScalar();
+                recordKey.Should().Be("KLR01-2607-0001",
+                    "the sales sync trigger enqueues the business key, not the surrogate id");
+            }
+
+            var result = _push.Push();
+            result.Success.Should().BeTrue(result.Error);
+
+            // The serialized batch must contain the sales event with a populated Data
+            // row fetched by journal_no. Pre-fix the event is omitted (Data null) — red.
+            var json = _fileWriter.Files.Values.Single();
+            var batch = JsonConvert.DeserializeObject<SyncBatch>(json);
+            var saleEvt = batch.Events.Single(
+                e => e.TableName == "sales" && e.RecordKey == "KLR01-2607-0001");
+            saleEvt.Data.Should().NotBeNull("FetchRowData must find the row by journal_no");
+            Convert.ToString(saleEvt.Data["journal_no"]).Should().Be("KLR01-2607-0001");
+
+            // The row was actually serialized -> it should be marked synced.
+            QueueStatusFor("sales").Should().Be("synced");
+        }
+
+        [Test]
+        public void Push_MarksUnfindableRow_Failed_NotSynced()
+        {
+            // A sync_queue row whose record_key does not exist in the table. The event
+            // cannot be serialized (FetchRowData returns null). It must NOT be silently
+            // marked synced — mark it failed so the drop is visible.
+            using (var cmd = _db.CreateCommand())
+            {
+                cmd.CommandText = @"
+                    INSERT INTO sync_queue (register_id, table_name, record_key, operation)
+                    VALUES ('01', 'sales', 'NO-SUCH-JOURNAL', 'I');";
+                cmd.ExecuteNonQuery();
+            }
+
+            var result = _push.Push();
+            result.Success.Should().BeTrue(result.Error);
+
+            QueueStatusFor("sales").Should().Be("failed",
+                "an unfindable row must be marked failed (visible), not silently synced");
+        }
+
+        private string QueueStatusFor(string table)
+        {
+            using (var cmd = _db.CreateCommand())
+            {
+                cmd.CommandText = "SELECT status FROM sync_queue WHERE table_name = @t";
+                cmd.Parameters.AddWithValue("@t", table);
+                return (string)cmd.ExecuteScalar();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## F04 — sync key-column mismatch (critical, 2-step verified)

Transaction-table sync events were silently dropped. The AFTER-INSERT/UPDATE/DELETE triggers enqueue `record_key = NEW.journal_no`, but `PushService.GetKeyColumn` mapped the 7 transaction tables to `"id"`. So `FetchRowData` ran `WHERE [id] = <journal_no>` (TEXT vs INTEGER PK), matched nothing, and `Push()` marked every entry synced anyway — **no sale/purchase/cash/memorial/order/transfer/adjustment ever synced between registers**, and the queue rows were flagged synced so they couldn't recover.

### Changes
- **`PushService.GetKeyColumn`** — return `"journal_no"` for sales, purchases, cash_transactions, memorial_journals, orders, stock_transfers, stock_adjustments (matches their triggers). `discounts`/`discount_partners`/`credit_cards` stay on `id` (no triggers; legitimately surrogate-keyed). Also repairs `PullService.ApplyUpdate`/`ApplyDelete`, which reuse `GetKeyColumn`.
- **`PushService.Push()`** — only `MarkSynced` entries actually serialized into the batch; mark the rest `failed` (visible) instead of silently `synced`.
- **`PushResult.EventCount`** — reports `batch.Events.Count`, not `pending.Count`, so a partial/empty batch is observable.

No schema/trigger changes (triggers were already correct), no schema-hash bump (the hash is over `TableMappings`, not `GetKeyColumn`), and the cloud path (`OutboxRouter` keys on `TableMappings.PrimaryKeyColumns[0]` = `journal_no`) already agreed — this aligns LAN with it.

### Tests (TDD: red → green)
New `PushServiceKeyColumnTests.cs` + one case in `PullServiceTests.cs`:
- `Push_RoundTripsSaleByJournalNo_NotById` — sale serializes into the batch with populated `Data` (was omitted). 
- `Push_MarksUnfindableRow_Failed_NotSynced` — an unfindable row is `failed`, not silently `synced`.
- `Pull_ApplyUpdate_FindsRow_ByJournalNo` — UPDATE lands by `journal_no` (was 0 rows).

All 3 fail on unfixed code; full `Kasir.Core.Tests` is **417/0** after the fix; `Kasir.Avalonia.slnx` builds clean (0 warnings).

### Follow-ups (separate PRs — not bundled here)
- **F24** — `PullService.ApplyInsert` still includes the surrogate `id`; fixing F04 makes the cross-register id-collision live, so this is the immediate next PR.
- **F05** — bounded retry of `failed` rows (recovers what this PR's guard now marks visible).
- **F25** — child/line tables (`sale_items`, …) still aren't synced.
